### PR TITLE
Fix: Dont retry on ActiveRecord::QueryCanceled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1 (Jan 25, 2024)
+
+- Fix: Do not retry on ActiveRecord::QueryCanceled errors
+
 ## 1.0.0 (Aug 24, 2023)
 
 - Feature: Add support for Rails 7

--- a/lib/activerecord/mysql/reconnect.rb
+++ b/lib/activerecord/mysql/reconnect.rb
@@ -32,7 +32,8 @@ module Activerecord::Mysql::Reconnect
   ]
 
   DO_NOT_HANDLE_ERROR = [
-    ActiveRecord::StatementTimeout
+    ActiveRecord::StatementTimeout,
+    ActiveRecord::QueryCanceled
   ]
 
   @@handle_r_error_messages = {

--- a/lib/activerecord/mysql/reconnect/version.rb
+++ b/lib/activerecord/mysql/reconnect/version.rb
@@ -1,7 +1,7 @@
 module Activerecord
   module Mysql
     module Reconnect
-      VERSION = '1.0.0'
+      VERSION = '1.0.1'
     end
   end
 end


### PR DESCRIPTION
For reasons I don't fully understand, when timing out while running a query on Aurora, it appears to return the error code that indicates a running query was killed by an external process as opposed to it hitting the execution timeout.

I didn't bother running it down as it doesn't really matter _why_ it does this, but I suspect it is something about the Aurora internals.

Additionally, this is a win because queries killed manually with `kill [pid]` will return the error code that turns into `ActiveRecord::QueryCanceled` - and we surely don't want those retrying either.

For those who are running Rails 6 and not using v1.0.0 of this gem this patch is included in https://github.com/planningcenter/pco-ops/pull/127 as well.