### PR TITLE
chore: Link to the successor of this gem.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # activerecord-mysql-reconnect
 
-Reconnect automatically when ActiveRecord is disconnected from MySQL. Supports Rails 7+ and MySQL 8.
+Reconnect automatically when ActiveRecord is disconnected from MySQL. Supports Rails 7.0 and MySQL 8.
+
+**NOTE: This gem has been superseded by [activerecord-retry-reads](https://github.com/planningcenter/activerecord-retry-reads) for
+Rails 7.1 and beyond.**
 
 [![Specs](https://github.com/planningcenter/activerecord-mysql-reconnect/actions/workflows/specs.yml/badge.svg)](https://github.com/planningcenter/activerecord-mysql-reconnect/actions/workflows/specs.yml)
 

--- a/activerecord-mysql-reconnect.gemspec
+++ b/activerecord-mysql-reconnect.gemspec
@@ -18,9 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  # We are going to stop using this in Rails 7.1 and beyond in favor of newly
-  # added reconnect / retry functionality. The Platform team will provide
-  # instructions for replacing this gem once 7.1 is released.
   spec.add_dependency 'activerecord', '~> 7.0.0'
   spec.add_dependency 'mysql2'
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
This gem should not be used with Rails 7.1 and up. We should archive this repository too.